### PR TITLE
Restore icon visibility for repeat icons

### DIFF
--- a/RecentItemsDisplay/RecentItemsDisplay.cs
+++ b/RecentItemsDisplay/RecentItemsDisplay.cs
@@ -53,6 +53,7 @@ internal class RecentItemsDisplayPlugin : Bep.BaseUnityPlugin
             if (_rows[j].Icon is {} img)
             {
                 img.Sprite = icon;
+                img.Visibility = MUI.Core.Visibility.Visible;
             }
             else
             {


### PR DESCRIPTION
If the RecentItemsDisplay has been hid via `UpdateHUD(null)`, rows that were previously showing would have hidden icons when `UpdateHUD` is called with a new log. This change fixes that issue by setting reused rows to have visible icons.